### PR TITLE
Fix critical sonar code smells and a bug

### DIFF
--- a/src/main/java/au/csiro/data61/aap/elf/core/readers/EthereumTransaction.java
+++ b/src/main/java/au/csiro/data61/aap/elf/core/readers/EthereumTransaction.java
@@ -55,7 +55,7 @@ public abstract class EthereumTransaction {
     public Boolean isSuccessful() throws ProgramException {
         final String status = this.getStatus();
         if (status == null) {
-            return null;
+            return false;
         } else {
             return status.equals("0x1");
         }

--- a/src/main/java/au/csiro/data61/aap/elf/core/values/BlockVariables.java
+++ b/src/main/java/au/csiro/data61/aap/elf/core/values/BlockVariables.java
@@ -32,26 +32,29 @@ public class BlockVariables {
     public static final String BLOCK_TIMESTAMP = "block.timestamp";
     public static final String BLOCK_TRANSACTIONS = "block.transactionCount";
 
+    private static final String TYPE_STRING = "string";
+    private static final String TYPE_BYTES = "bytes";
+
     static {
         BLOCK_VARIABLES = new HashSet<>();
         addBlockVariable(BLOCK_DIFFICULTY, "int", EthereumBlock::getDifficulty);
-        addBlockVariable(BLOCK_EXTRA_DATA, "string", EthereumBlock::getExtraData);
+        addBlockVariable(BLOCK_EXTRA_DATA, TYPE_STRING, EthereumBlock::getExtraData);
         addBlockVariable(BLOCK_GAS_LIMIT, "int", EthereumBlock::getGasLimit);
         addBlockVariable(BLOCK_GAS_USED, "int", EthereumBlock::getGasUsed);
-        addBlockVariable(BLOCK_HASH, "bytes", EthereumBlock::getHash);
-        addBlockVariable(BLOCK_LOGS_BLOOM, "string", EthereumBlock::getLogsBloom);
+        addBlockVariable(BLOCK_HASH, TYPE_BYTES, EthereumBlock::getHash);
+        addBlockVariable(BLOCK_LOGS_BLOOM, TYPE_STRING, EthereumBlock::getLogsBloom);
         addBlockVariable(BLOCK_MINER, "address", EthereumBlock::getMiner);
         addBlockVariable(BLOCK_NONCE, "int", EthereumBlock::getNonce);
         addBlockVariable(BLOCK_NUMBER, "int", EthereumBlock::getNumber);
-        addBlockVariable(BLOCK_PARENT_HASH, "bytes", EthereumBlock::getParentHash);
-        addBlockVariable(BLOCK_RECEIPTS_ROOT, "bytes", EthereumBlock::getReceiptsRoot);
-        addBlockVariable(BLOCK_SHA3_UNCLES, "bytes", EthereumBlock::getSha3uncles);
+        addBlockVariable(BLOCK_PARENT_HASH, TYPE_BYTES, EthereumBlock::getParentHash);
+        addBlockVariable(BLOCK_RECEIPTS_ROOT, TYPE_BYTES, EthereumBlock::getReceiptsRoot);
+        addBlockVariable(BLOCK_SHA3_UNCLES, TYPE_BYTES, EthereumBlock::getSha3uncles);
         addBlockVariable(BLOCK_SIZE, "int", EthereumBlock::getSize);
-        addBlockVariable(BLOCK_STATE_ROOT, "bytes", EthereumBlock::getStateRoot);
+        addBlockVariable(BLOCK_STATE_ROOT, TYPE_BYTES, EthereumBlock::getStateRoot);
         addBlockVariable(BLOCK_TIMESTAMP, "int", EthereumBlock::getTimestamp);
         addBlockVariable(BLOCK_TOTAL_DIFFICULTY, "int", EthereumBlock::getTotalDifficulty);
         addBlockVariable(BLOCK_TRANSACTIONS, "int", block -> BigInteger.valueOf(block.transactionCount()));
-        addBlockVariable(BLOCK_TRANSACTION_ROOT, "string", EthereumBlock::getTransactionsRoot);
+        addBlockVariable(BLOCK_TRANSACTION_ROOT, TYPE_STRING, EthereumBlock::getTransactionsRoot);
     }
 
     private static void addBlockVariable(String name, String type, Function<EthereumBlock, Object> blockValueExtractor) {

--- a/src/main/java/au/csiro/data61/aap/elf/core/values/TransactionVariables.java
+++ b/src/main/java/au/csiro/data61/aap/elf/core/values/TransactionVariables.java
@@ -34,6 +34,8 @@ public class TransactionVariables {
     public static final String TX_STATUS = "tx.status";
     public static final String TX_SUCCESS = "tx.success";
 
+    private static final String TYPE_STRING = "string";
+
     static {
         TRANSACTION_VARIABLES = new HashSet<>();
         addTransactionVariable(TX_FROM, "address", EthereumTransaction::getFrom);
@@ -43,19 +45,19 @@ public class TransactionVariables {
         addTransactionVariable(TX_TO, "address", EthereumTransaction::getTo);
         addTransactionVariable(TX_BLOCKNUMBER, "int", EthereumTransaction::getBlockNumber);
         addTransactionVariable(TX_V, "int", EthereumTransaction::getV);
-        addTransactionVariable(TX_R, "string", EthereumTransaction::getR);
+        addTransactionVariable(TX_R, TYPE_STRING, EthereumTransaction::getR);
         addTransactionVariable(TX_VALUE, "int", EthereumTransaction::getValue);
         addTransactionVariable(TX_BLOCKHASH, "bytes", EthereumTransaction::getBlockHash);
-        addTransactionVariable(TX_INPUT, "string", EthereumTransaction::getInput);
+        addTransactionVariable(TX_INPUT, TYPE_STRING, EthereumTransaction::getInput);
         addTransactionVariable(TX_TRANSACTIONINDEX, "int", EthereumTransaction::getTransactionIndex);
         addTransactionVariable(TX_NONCE, "int", EthereumTransaction::getNonce);
-        addTransactionVariable(TX_S, "string", EthereumTransaction::getS);
+        addTransactionVariable(TX_S, TYPE_STRING, EthereumTransaction::getS);
         addTransactionVariable(TX_CUMULATIVE_GAS_USED, "int", EthereumTransaction::getCumulativeGasUsed);
         addTransactionVariable(TX_GAS_USED, "int", EthereumTransaction::getGasUsed);
-        addTransactionVariable(TX_CONTRACT_ADRESS, "string", EthereumTransaction::getContractAddress);
-        addTransactionVariable(TX_LOGS_BLOOM, "string", EthereumTransaction::getLogsBloom);
-        addTransactionVariable(TX_ROOT, "string", EthereumTransaction::getRoot);
-        addTransactionVariable(TX_STATUS, "string", EthereumTransaction::getStatus);
+        addTransactionVariable(TX_CONTRACT_ADRESS, TYPE_STRING, EthereumTransaction::getContractAddress);
+        addTransactionVariable(TX_LOGS_BLOOM, TYPE_STRING, EthereumTransaction::getLogsBloom);
+        addTransactionVariable(TX_ROOT, TYPE_STRING, EthereumTransaction::getRoot);
+        addTransactionVariable(TX_STATUS, TYPE_STRING, EthereumTransaction::getStatus);
         addTransactionVariable(TX_SUCCESS, "bool", EthereumTransaction::isSuccessful);
     }
 

--- a/src/main/java/au/csiro/data61/aap/elf/core/writers/AddXesEventInstruction.java
+++ b/src/main/java/au/csiro/data61/aap/elf/core/writers/AddXesEventInstruction.java
@@ -21,7 +21,7 @@ public class AddXesEventInstruction extends AddXesElementInstruction {
     @Override
     protected void startElement(XesWriter writer, ProgramState state, String pid, String piid) throws ProgramException {
         final String eid = this.getId(state, this.eid);
-        writer.startEvent(pid, piid, eid);
+        XesWriter.startEvent(writer, pid, piid, eid);
     }
 
 }

--- a/src/main/java/au/csiro/data61/aap/elf/core/writers/XesWriter.java
+++ b/src/main/java/au/csiro/data61/aap/elf/core/writers/XesWriter.java
@@ -81,14 +81,14 @@ public class XesWriter extends DataWriter {
         return;
     }
 
-    public void startEvent(String inputPid, String inputPiid, String inputEid) {
+    public static void startEvent(XesWriter writer, String inputPid, String inputPiid, String inputEid) {
         final String pid = inputPid == null ? DEFAULT_PID : inputPid;
         final String piid = inputPiid == null ? DEFAULT_PIID : inputPiid;
         final String eid = inputEid == null ? String.format("%s%s", DEFAULT_EID, Long.toString(EID++)) : inputEid;
         LOGGER.info(String.format("Event %s in trace %s in log %s started.", eid, piid, pid));
 
-        this.findOrCreateTrace(pid, piid);
-        this.findOrCreateEvent(pid, piid, eid);
+        writer.findOrCreateTrace(pid, piid);
+        writer.findOrCreateEvent(pid, piid, eid);
     }
 
     private void findOrCreateEvent(String pid, String piid, String eid) {
@@ -195,7 +195,9 @@ public class XesWriter extends DataWriter {
             for (Entry<String, XLog> entry : logs.entrySet()) {
                 final String filename = String.format("log_%s_%s.xes", entry.getKey(), filenameSuffix);
                 final File file = new File(folder, filename);
-                serializer.serialize(entry.getValue(), new FileOutputStream(file));
+                try (final FileOutputStream outputStream = new FileOutputStream(file);) {
+                    serializer.serialize(entry.getValue(), outputStream);
+                }
             }
         } catch (Throwable t) {
             LOGGER.info("Xes export finished unsuccessfully.");

--- a/src/main/java/au/csiro/data61/aap/elf/generation/BitMappingItem.java
+++ b/src/main/java/au/csiro/data61/aap/elf/generation/BitMappingItem.java
@@ -8,10 +8,10 @@ import org.antlr.v4.runtime.Token;
 /**
  * BitMappingItem
  */
-class BitMappingItem extends GeneratorItem {
+class BitMappingItem<T> extends GeneratorItem {
     private BigInteger from;
     private BigInteger to;
-    private List<?> values;
+    private List<T> values;
     private String encodedAttribute;
     private String targetVariable;
 
@@ -24,7 +24,9 @@ class BitMappingItem extends GeneratorItem {
     }
 
     public void setFrom(BigInteger from) {
-        assert from != null;
+        if (from == null) {
+            throw new IllegalArgumentException("BitMappingItem.setFrom: null not allowed!");
+        }
         this.from = from;
     }
 
@@ -33,16 +35,20 @@ class BitMappingItem extends GeneratorItem {
     }
 
     public void setTo(BigInteger to) {
-        assert to != null;
+        if (to == null) {
+            throw new IllegalArgumentException("BitMappingItem.setTo: null not allowed!");
+        }
         this.to = to;
     }
 
-    public List<?> getValues() {
+    public List<T> getValues() {
         return this.values;
     }
 
-    public void setValues(List<?> values) {
-        assert values != null;
+    public void setValues(List<T> values) {
+        if (values == null) {
+            throw new IllegalArgumentException("BitMappingItem.setValues: null not allowed!");
+        }
         this.values = values;
     }
 

--- a/src/main/java/au/csiro/data61/aap/elf/generation/ItemGenerator.java
+++ b/src/main/java/au/csiro/data61/aap/elf/generation/ItemGenerator.java
@@ -274,9 +274,10 @@ public class ItemGenerator extends BaseGenerator {
     }
 
     private void generateBitMappingEnum(BitMappingItem item) {
-        final String values = item.getValues()
+        final Object values = item.getValues()
             .stream()
             .map(val -> val instanceof String ? val.toString().toUpperCase() : this.createEnumValue(val))
+            // .map(val -> this.createEnumValue(val))
             .collect(Collectors.joining(", "));
 
         final String code = String.format("enum %s {%s}", this.getEnumName(item), values);

--- a/src/main/java/au/csiro/data61/aap/elf/generation/ValueDictionaryItem.java
+++ b/src/main/java/au/csiro/data61/aap/elf/generation/ValueDictionaryItem.java
@@ -7,24 +7,24 @@ import org.antlr.v4.runtime.Token;
 /**
  * ValueDictionaryItem
  */
-class ValueDictionaryItem extends GeneratorItem {
+class ValueDictionaryItem<S, T> extends GeneratorItem {
     private String targetVariable;
     private String targetType;
     private String encodedAttribute;
     private String encodedType;
     private Object defaultValue;
-    private List<?> fromValues;
-    private List<?> toValues;
+    private List<S> fromValues;
+    private List<T> toValues;
 
     ValueDictionaryItem(Token token, String specification) {
         super(token, specification);
     }
 
-    List<?> getFromValues() {
+    List<S> getFromValues() {
         return this.fromValues;
     }
 
-    void setFromValues(List<?> fromValues) {
+    void setFromValues(List<S> fromValues) {
         this.fromValues = fromValues;
     }
 
@@ -60,11 +60,11 @@ class ValueDictionaryItem extends GeneratorItem {
         this.encodedType = encodedType;
     }
 
-    List<?> getToValues() {
+    List<T> getToValues() {
         return this.toValues;
     }
 
-    void setToValues(List<?> toValues) {
+    void setToValues(List<T> toValues) {
         this.toValues = toValues;
     }
 

--- a/src/main/java/au/csiro/data61/aap/elf/library/Library.java
+++ b/src/main/java/au/csiro/data61/aap/elf/library/Library.java
@@ -23,6 +23,14 @@ public class Library {
     private static final Logger LOGGER = Logger.getLogger(Library.class.getName());
     public static final Library INSTANCE = new Library();
 
+    private static final String TYPE_STRING = "string";
+    private static final String TYPE_ADDRESS = "address";
+    private static final String TYPE_BOOLLIST = "bool[]";
+    private static final String TYPE_STRINGLIST = "string[]";
+    private static final String TYPE_INTLIST = "int[]";
+    private static final String TYPE_BYTELIST = "byte[]";
+    private static final String TYPE_ADDRESSLIST = "address[]";
+
     private final Map<String, List<LibraryEntry>> registeredMethods;
 
     private Library() {
@@ -33,47 +41,119 @@ public class Library {
             this.addMethod(new MethodSignature("multiply", "int", "int", "int"), IntegerOperations::multiply);
             this.addMethod(new MethodSignature("subtract", "int", "int", "int"), IntegerOperations::subtract);
             this.addMethod(new MethodSignature("divide", "int", "int", "int"), IntegerOperations::divide);
-            this.addMethod(new MethodSignature("contains", "bool", "address[]", "address"), ListOperations::contains);
-            this.addMethod(new MethodSignature("contains", "bool", "int[]", "int"), ListOperations::contains);
-            this.addMethod(new MethodSignature("add", null, "int[]", "int"), ListOperations::addElement);
-            this.addMethod(new MethodSignature("add", null, "address[]", "address"), ListOperations::addElement);
-            this.addMethod(new MethodSignature("remove", null, "address[]", "address"), ListOperations::removeElement);
-            this.addMethod(new MethodSignature("clear", null, "address[]"), ListOperations::clear);
+            this.addMethod(new MethodSignature("contains", "bool", TYPE_ADDRESSLIST, TYPE_ADDRESS), ListOperations::contains);
+            this.addMethod(new MethodSignature("contains", "bool", TYPE_INTLIST, "int"), ListOperations::contains);
+            this.addMethod(new MethodSignature("add", null, TYPE_INTLIST, "int"), ListOperations::addElement);
+            this.addMethod(new MethodSignature("add", null, TYPE_ADDRESSLIST, TYPE_ADDRESS), ListOperations::addElement);
+            this.addMethod(new MethodSignature("remove", null, TYPE_ADDRESSLIST, TYPE_ADDRESS), ListOperations::removeElement);
+            this.addMethod(new MethodSignature("clear", null, TYPE_ADDRESSLIST), ListOperations::clear);
 
-            this.addMethod(ValueDictionary::boolToBool, "bool", ValueDictionary.METHOD_NAME, "bool", "bool", "bool[]", "bool[]");
-            this.addMethod(ValueDictionary::stringToBool, "bool", ValueDictionary.METHOD_NAME, "byte", "bool", "byte[]", "bool[]");
-            this.addMethod(ValueDictionary::intToBool, "bool", ValueDictionary.METHOD_NAME, "int", "bool", "int[]", "bool[]");
-            this.addMethod(ValueDictionary::stringToBool, "bool", ValueDictionary.METHOD_NAME, "string", "bool", "string[]", "bool[]");
-            this.addMethod(ValueDictionary::boolToString, "byte", ValueDictionary.METHOD_NAME, "bool", "byte", "bool[]", "byte[]");
-            this.addMethod(ValueDictionary::stringToString, "byte", ValueDictionary.METHOD_NAME, "byte", "byte", "byte[]", "byte[]");
-            this.addMethod(ValueDictionary::intToString, "byte", ValueDictionary.METHOD_NAME, "int", "byte", "int[]", "byte[]");
-            this.addMethod(ValueDictionary::stringToString, "byte", ValueDictionary.METHOD_NAME, "string", "byte", "string[]", "byte[]");
-            this.addMethod(ValueDictionary::boolToInt, "int", ValueDictionary.METHOD_NAME, "bool", "int", "bool[]", "int[]");
-            this.addMethod(ValueDictionary::stringToInt, "int", ValueDictionary.METHOD_NAME, "byte", "int", "byte[]", "int[]");
-            this.addMethod(ValueDictionary::intToInt, "int", ValueDictionary.METHOD_NAME, "int", "int", "int[]", "int[]");
-            this.addMethod(ValueDictionary::stringToInt, "int", ValueDictionary.METHOD_NAME, "string", "int", "string[]", "int[]");
-            this.addMethod(ValueDictionary::boolToString, "string", ValueDictionary.METHOD_NAME, "bool", "string", "bool[]", "string[]");
-            this.addMethod(ValueDictionary::stringToString, "string", ValueDictionary.METHOD_NAME, "byte", "string", "byte[]", "string[]");
-            this.addMethod(ValueDictionary::intToString, "string", ValueDictionary.METHOD_NAME, "int", "string", "int[]", "string[]");
+            this.addMethod(ValueDictionary::boolToBool, "bool", ValueDictionary.METHOD_NAME, "bool", "bool", TYPE_BOOLLIST, TYPE_BOOLLIST);
+            this.addMethod(
+                ValueDictionary::stringToBool,
+                "bool",
+                ValueDictionary.METHOD_NAME,
+                "byte",
+                "bool",
+                TYPE_BYTELIST,
+                TYPE_BOOLLIST
+            );
+            this.addMethod(ValueDictionary::intToBool, "bool", ValueDictionary.METHOD_NAME, "int", "bool", TYPE_INTLIST, TYPE_BOOLLIST);
+            this.addMethod(
+                ValueDictionary::stringToBool,
+                "bool",
+                ValueDictionary.METHOD_NAME,
+                TYPE_STRING,
+                "bool",
+                TYPE_STRINGLIST,
+                TYPE_BOOLLIST
+            );
+            this.addMethod(
+                ValueDictionary::boolToString,
+                "byte",
+                ValueDictionary.METHOD_NAME,
+                "bool",
+                "byte",
+                TYPE_BOOLLIST,
+                TYPE_BYTELIST
+            );
             this.addMethod(
                 ValueDictionary::stringToString,
-                "string",
+                "byte",
                 ValueDictionary.METHOD_NAME,
-                "string",
-                "string",
-                "string[]",
-                "string[]"
+                "byte",
+                "byte",
+                TYPE_BYTELIST,
+                TYPE_BYTELIST
             );
-            this.addMethod(BitMapping::mapBitsToString, "string", BitMapping.METHOD_NAME, "int", "int", "int", "string[]");
-            this.addMethod(BitMapping::mapBitsToString, "byte", BitMapping.METHOD_NAME, "int", "int", "int", "byte[]");
-            this.addMethod(BitMapping::mapBitsToInt, "int", BitMapping.METHOD_NAME, "int", "int", "int", "int[]");
-            this.addMethod(BitMapping::mapBitsToBool, "bool", BitMapping.METHOD_NAME, "int", "int", "int", "bool[]");
+            this.addMethod(ValueDictionary::intToString, "byte", ValueDictionary.METHOD_NAME, "int", "byte", TYPE_INTLIST, TYPE_BYTELIST);
+            this.addMethod(
+                ValueDictionary::stringToString,
+                "byte",
+                ValueDictionary.METHOD_NAME,
+                TYPE_STRING,
+                "byte",
+                TYPE_STRINGLIST,
+                TYPE_BYTELIST
+            );
+            this.addMethod(ValueDictionary::boolToInt, "int", ValueDictionary.METHOD_NAME, "bool", "int", TYPE_BOOLLIST, TYPE_INTLIST);
+            this.addMethod(ValueDictionary::stringToInt, "int", ValueDictionary.METHOD_NAME, "byte", "int", TYPE_BYTELIST, TYPE_INTLIST);
+            this.addMethod(ValueDictionary::intToInt, "int", ValueDictionary.METHOD_NAME, "int", "int", TYPE_INTLIST, TYPE_INTLIST);
+            this.addMethod(
+                ValueDictionary::stringToInt,
+                "int",
+                ValueDictionary.METHOD_NAME,
+                TYPE_STRING,
+                "int",
+                TYPE_STRINGLIST,
+                TYPE_INTLIST
+            );
+            this.addMethod(
+                ValueDictionary::boolToString,
+                TYPE_STRING,
+                ValueDictionary.METHOD_NAME,
+                "bool",
+                TYPE_STRING,
+                TYPE_BOOLLIST,
+                TYPE_STRINGLIST
+            );
+            this.addMethod(
+                ValueDictionary::stringToString,
+                TYPE_STRING,
+                ValueDictionary.METHOD_NAME,
+                "byte",
+                TYPE_STRING,
+                TYPE_BYTELIST,
+                TYPE_STRINGLIST
+            );
+            this.addMethod(
+                ValueDictionary::intToString,
+                TYPE_STRING,
+                ValueDictionary.METHOD_NAME,
+                "int",
+                TYPE_STRING,
+                TYPE_INTLIST,
+                TYPE_STRINGLIST
+            );
+            this.addMethod(
+                ValueDictionary::stringToString,
+                TYPE_STRING,
+                ValueDictionary.METHOD_NAME,
+                TYPE_STRING,
+                TYPE_STRING,
+                TYPE_STRINGLIST,
+                TYPE_STRINGLIST
+            );
+            this.addMethod(BitMapping::mapBitsToString, TYPE_STRING, BitMapping.METHOD_NAME, "int", "int", "int", TYPE_STRINGLIST);
+            this.addMethod(BitMapping::mapBitsToString, "byte", BitMapping.METHOD_NAME, "int", "int", "int", TYPE_BYTELIST);
+            this.addMethod(BitMapping::mapBitsToInt, "int", BitMapping.METHOD_NAME, "int", "int", "int", TYPE_INTLIST);
+            this.addMethod(BitMapping::mapBitsToBool, "bool", BitMapping.METHOD_NAME, "int", "int", "int", TYPE_BOOLLIST);
 
-            this.addMethod(ListOperations::newAddressArray, "address[]", "newAddressArray");
-            this.addMethod(ListOperations::newBoolArray, "bool[]", "newBoolArray");
-            this.addMethod(ListOperations::newByteArray, "byte[]", "newByteArray");
-            this.addMethod(ListOperations::newIntArray, "int[]", "newIntArray");
-            this.addMethod(ListOperations::newStringArray, "string[]", "newStringArray");
+            this.addMethod(ListOperations::newAddressArray, TYPE_ADDRESSLIST, "newAddressArray");
+            this.addMethod(ListOperations::newBoolArray, TYPE_BOOLLIST, "newBoolArray");
+            this.addMethod(ListOperations::newByteArray, TYPE_BYTELIST, "newByteArray");
+            this.addMethod(ListOperations::newIntArray, TYPE_INTLIST, "newIntArray");
+            this.addMethod(ListOperations::newStringArray, TYPE_STRINGLIST, "newStringArray");
         } catch (LibraryException e) {
             e.printStackTrace();
         }

--- a/src/main/java/au/csiro/data61/aap/elf/parsing/VariableExistenceAnalyzer.java
+++ b/src/main/java/au/csiro/data61/aap/elf/parsing/VariableExistenceAnalyzer.java
@@ -122,7 +122,7 @@ public class VariableExistenceAnalyzer extends SemanticAnalyzer {
         }
 
         if (this.isFilterConstant(variableName)) {
-            this.addError(ctx.start, String.format("Variable '%s' not defined."));
+            this.addError(ctx.start, String.format("Variable '%s' not defined.", variableName));
         }
     }
 


### PR DESCRIPTION
Fix most of the critical sonar code smells. Fixes occurrences of: "Remove usage of generic wildcard type", "Null is returned but a Boolean is expected", "Define a constant instead of duplicating literal", "Make the enclosing method static", "change try to a try-with-resources".

Also fixes a bug where no argument was passed to a format string.