### PR TITLE
#82 - hotfix address names contain quotes

### DIFF
--- a/src/main/java/blf/blockchains/hyperledger/HyperledgerListener.java
+++ b/src/main/java/blf/blockchains/hyperledger/HyperledgerListener.java
@@ -136,6 +136,13 @@ public class HyperledgerListener extends BaseBlockchainListener {
             addressNames = stringLiteral.stream().map(ParseTree::getText).collect(Collectors.toList());
         }
 
+        // remove leading and closing " from all addresses
+        for (int i = 0; i < addressNames.size(); i++) {
+            if (addressNames.get(i).charAt(0) == '\"') {
+                addressNames.set(i, addressNames.get(i).substring(1, addressNames.get(i).length() - 1));
+            }
+        }
+
         final HyperledgerLogEntryFilterInstruction logEntryFilterInstruction = new HyperledgerLogEntryFilterInstruction(
             addressNames,
             eventName,


### PR DESCRIPTION
Fixes the bug we found in the meeting today by sanitizing the addressNames List.

I didn't find a way to do it in a for each loop. When calling substring() and assigning it to the same identifier again it seemed to create a local variable in the loop and not actually change the List. So I did it with a normal index-based loop.