### PR TITLE
#95 - publish the test manifest from the meeting

### DIFF
--- a/src/main/resources/HyperBasic.bcql
+++ b/src/main/resources/HyperBasic.bcql
@@ -12,7 +12,7 @@ SET CONNECTION {
 
 SET OUTPUT FOLDER "./test_output"
 
-BLOCKS (10) (15) {
+BLOCKS (12) (20) {
    LOG ENTRIES ("basic") (basicTestEvent(string payload)) {
         EMIT LOG LINE ("payload: '", payload, "' .");
    }

--- a/src/main/resources/HyperBasic.bcql
+++ b/src/main/resources/HyperBasic.bcql
@@ -1,0 +1,19 @@
+// Author: Tobias Petrich
+
+SET BLOCKCHAIN "Hyperledger"
+
+SET CONNECTION {
+   "hyperledger/connection-org1.yaml",
+   "hyperledger/server.key",
+   "hyperledger/server.crt",
+   "Org1MSP",
+   "mychannel"
+}
+
+SET OUTPUT FOLDER "./test_output"
+
+BLOCKS (10) (15) {
+   LOG ENTRIES ("basic") (basicTestEvent(string payload)) {
+        EMIT LOG LINE ("payload: '", payload, "' .");
+   }
+}


### PR DESCRIPTION
Closes #95.

The Hyperledger manifest for extracting some events from the basic-asset-transfer chaincode.

I will leave this as draft until the hotfixes are merged and I am able to test it through the ssh tunnel in the vm environment.