### PR TITLE
#99 - test the extraction of structured event data of hyperledger

### DIFF
--- a/src/main/java/blf/blockchains/hyperledger/HyperledgerListener.java
+++ b/src/main/java/blf/blockchains/hyperledger/HyperledgerListener.java
@@ -90,6 +90,11 @@ public class HyperledgerListener extends BaseBlockchainListener {
         this.composer.instructionListsStack.add(new LinkedList<>());
     }
 
+    @Override
+    public void exitLogEntryFilter(BcqlParser.LogEntryFilterContext ctx) {
+        this.composer.instructionListsStack.add(new LinkedList<>());
+    }
+
     /**
      * When exiting a scope parse tree node, the listener identifies which filter was specified in the local scope
      * context and calls the corresponding handler method accordingly.
@@ -105,6 +110,9 @@ public class HyperledgerListener extends BaseBlockchainListener {
         if (blockFilterCtx != null) {
             handleBlockFilterScopeExit(blockFilterCtx);
         }
+        if (logEntryCtx != null) {
+            handleLogEntryFilterScopeExit(logEntryCtx);
+        }
     }
 
     /**
@@ -116,8 +124,7 @@ public class HyperledgerListener extends BaseBlockchainListener {
      * @param logEntryCtx - logEntryFilter context
      */
 
-    @Override
-    public void enterLogEntryFilter(BcqlParser.LogEntryFilterContext logEntryCtx) {
+    public void handleLogEntryFilterScopeExit(BcqlParser.LogEntryFilterContext logEntryCtx) {
         final BcqlParser.AddressListContext addressListCtx = logEntryCtx.addressList();
         final BcqlParser.LogEntrySignatureContext logEntrySignatureCtx = logEntryCtx.logEntrySignature();
 
@@ -175,7 +182,8 @@ public class HyperledgerListener extends BaseBlockchainListener {
         final HyperledgerLogEntryFilterInstruction logEntryFilterInstruction = new HyperledgerLogEntryFilterInstruction(
             addressNames,
             eventName,
-            entryParameters
+            entryParameters,
+            this.composer.instructionListsStack.pop()
         );
 
         this.composer.addInstruction(logEntryFilterInstruction);

--- a/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerLogEntryFilterInstruction.java
+++ b/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerLogEntryFilterInstruction.java
@@ -279,4 +279,18 @@ public class HyperledgerLogEntryFilterInstruction extends FilterInstruction {
             this.exceptionHandler.handleExceptionAndDecideOnAbort(message, new JSONException(message));
         }
     }
+
+    /**
+     * Executes the nested EMIT instructions.
+     *
+     * @param hyperledgerProgramState The current ProgramState of the BLF.
+     */
+    private void executeNestedInstructions(HyperledgerProgramState hyperledgerProgramState) {
+        try {
+            this.executeInstructions(hyperledgerProgramState);
+        } catch (ProgramException err) {
+            String errorMsg = "Unable to execute instructions";
+            hyperledgerProgramState.getExceptionHandler().handleExceptionAndDecideOnAbort(errorMsg, err);
+        }
+    }
 }

--- a/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerLogEntryFilterInstruction.java
+++ b/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerLogEntryFilterInstruction.java
@@ -3,6 +3,7 @@ package blf.blockchains.hyperledger.instructions;
 import blf.blockchains.hyperledger.state.HyperledgerProgramState;
 import blf.core.exceptions.ExceptionHandler;
 import blf.core.exceptions.ProgramException;
+import blf.core.instructions.FilterInstruction;
 import blf.core.interfaces.Instruction;
 import blf.core.state.ProgramState;
 import org.antlr.v4.runtime.misc.Pair;
@@ -20,7 +21,7 @@ import java.util.logging.Logger;
  * Logging Framework. It extracts the requested event from the current Block and stores the extracted parameter values
  * in the ProgramState.
  */
-public class HyperledgerLogEntryFilterInstruction implements Instruction {
+public class HyperledgerLogEntryFilterInstruction extends FilterInstruction {
 
     private final ExceptionHandler exceptionHandler;
     private final Logger logger;
@@ -38,8 +39,11 @@ public class HyperledgerLogEntryFilterInstruction implements Instruction {
     public HyperledgerLogEntryFilterInstruction(
         final List<String> addressNames,
         String eventName,
-        List<Pair<String, String>> entryParameters
+        List<Pair<String, String>> entryParameters,
+        List<Instruction> nestedInstructions
     ) {
+        super(nestedInstructions);
+
         this.addressNames = addressNames;
         this.eventName = eventName;
         this.entryParameters = entryParameters;
@@ -125,6 +129,9 @@ public class HyperledgerLogEntryFilterInstruction implements Instruction {
 
                 setStateValue(hyperledgerProgramState, parameterName, parameterType, eventObj);
             }
+
+            // emit what we extracted
+            executeNestedInstructions(hyperledgerProgramState);
         } catch (JSONException e) {
             // payload does not contain a nested json object with the given eventName
             parseFlatJsonPayload(hyperledgerProgramState, ce, obj);
@@ -148,6 +155,9 @@ public class HyperledgerLogEntryFilterInstruction implements Instruction {
 
                 setStateValue(hyperledgerProgramState, parameterName, parameterType, obj);
             }
+
+            // emit what we extracted
+            executeNestedInstructions(hyperledgerProgramState);
         }
     }
 
@@ -176,6 +186,9 @@ public class HyperledgerLogEntryFilterInstruction implements Instruction {
                 String parameterType = this.entryParameters.get(0).a;
                 String parameterName = this.entryParameters.get(0).b;
                 setStateValue(hyperledgerProgramState, parameterName, parameterType, payloadString, ce.getPayload());
+
+                // emit what we extracted
+                executeNestedInstructions(hyperledgerProgramState);
             } else {
                 this.exceptionHandler.handleExceptionAndDecideOnAbort(
                     "We expect exactly one parameter when extracting unstructured data",

--- a/src/main/resources/CryptoKittiesAsHyper.bcql
+++ b/src/main/resources/CryptoKittiesAsHyper.bcql
@@ -1,0 +1,48 @@
+SET BLOCKCHAIN "Hyperledger"
+
+SET CONNECTION {
+   "hyperledger/connection-org1.yaml",
+   "hyperledger/server.key",
+   "hyperledger/server.crt",
+   "Org1MSP",
+   "mychannel"
+}
+
+SET OUTPUT FOLDER "./test_output"
+
+int[] kitties = newIntArray();
+BLOCKS (32) (91) {
+    LOG ENTRIES ("kitties") (Birth(string owner, uint256 kittyId, uint256 matronID, uint256 sireID, uint256 genes)) {
+        add(kitties, kittyId);
+        EMIT XES EVENT ()(kittyId)()("birth" as xs:string concept:name);
+
+        bool containsMatron = contains(kitties, matronID);
+        IF (containsMatron) {
+            EMIT XES EVENT ()(matronID)()("became mother" as xs:string concept:name);
+        }
+
+        bool containsSire = contains(kitties, sireID);
+        IF (containsSire) {
+            EMIT XES EVENT ()(sireID)()("became father" as xs:string concept:name);
+        }
+    }
+
+    LOG ENTRIES ("kitties") (Transfer(string from, string to, uint256 kittyID)) {
+        bool containsKitty = contains(kitties, kittyID);
+        IF (containsKitty) {
+            EMIT XES EVENT ()(kittyID)()("transferred" as xs:string concept:name);
+        }
+    }
+
+    LOG ENTRIES ("kitties") (Pregnant(string owner, uint256 matronID, uint256 sireID, string matronCooldown)) {
+        bool containsMatron = contains(kitties, matronID);
+        IF (containsMatron) {
+            EMIT XES EVENT ()(matronID)()("conceived as mother" as xs:string concept:name);
+        }
+
+        bool containsSire = contains(kitties, sireID);
+        IF (containsSire) {
+            EMIT XES EVENT ()(sireID)()("conceived as father" as xs:string concept:name);
+        }
+    }
+}

--- a/src/main/resources/HyperKitties.bcql
+++ b/src/main/resources/HyperKitties.bcql
@@ -1,0 +1,33 @@
+// Author: Tobias Petrich
+
+SET BLOCKCHAIN "Hyperledger"
+
+SET CONNECTION {
+   "hyperledger/connection-org1.yaml",
+   "hyperledger/server.key",
+   "hyperledger/server.crt",
+   "Org1MSP",
+   "mychannel"
+}
+
+SET OUTPUT FOLDER "./test_output"
+
+BLOCKS (32) (91) {
+   LOG ENTRIES ("kitties") (Birth(string owner, int newKittenID, int matronID, int sireID, int genes)) {
+        EMIT LOG LINE ("Birth: '", owner, " ", newKittenID, " ", genes, "'.");
+        EMIT CSV ROW ("Birth") (owner, newKittenID, matronID, sireID, genes);
+        EMIT XES EVENT ("Birth")()()(owner as xs:string owner, newKittenID as xs:int newKittenID, matronID as xs:int matronID, sireID as xs:int sireID, genes as xs:int genes);
+   }
+
+   LOG ENTRIES ("kitties") (Transfer(string from, string to, int kittyID)) {
+        EMIT LOG LINE ("Transfer: '", from, " ", to, " ", kittyID, "'.");
+        EMIT CSV ROW ("Transfer")(from, to, kittyID);
+        EMIT XES EVENT ("Transfer")()()(from as xs:string from, to as xs:string to, kittyID as xs:int kittyID);
+   }
+
+   LOG ENTRIES ("kitties") (Pregnant(string owner, int matronID, int sireID, string matronCooldown)) {
+        EMIT LOG LINE ("Pregnant: '", owner, " ", matronID, " ", sireID, " ", matronCooldown, "'.");
+        EMIT CSV ROW ("Pregnant")(owner, matronID, sireID, matronCooldown);
+        EMIT XES EVENT ("Pregnant")()()(owner as xs:string owner, matronID as xs:int matronID, sireID as xs:int sireID, matronCooldown as xs:string matronCooldown);
+   }
+}


### PR DESCRIPTION
Fixes #99. Fixes #106.

Adds two example manifests for extracting structured JSON data from the HyperKitties smart contract.

Also fixes an issue where the contents of the ValueStore were emitted on every encountered block, even when there were no events extracted. We fixed this by changing the LogEntryFilterInstruction creation back to the exitScope() function but giving it its own set of nested instructions (the EMIT statements), which we only execute when we have extracted an event.