### PR TITLE
#108 - blf hyperledger does not exit when analyzing until the very last block in the ledger

### DIFF
--- a/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerBlockFilterInstruction.java
+++ b/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerBlockFilterInstruction.java
@@ -76,6 +76,12 @@ public class HyperledgerBlockFilterInstruction extends FilterInstruction {
                     String errorMsg = String.format("Unable to execute instructions");
                     exceptionHandler.handleExceptionAndDecideOnAbort(errorMsg, err);
                 }
+
+                if (currentBlockNumber.compareTo(toBlockNumber) == 0) {
+                    synchronized (network) {
+                        network.notifyAll();
+                    }
+                }
             }
         });
         synchronized (network) {


### PR DESCRIPTION
Fixes #108.

Adds a check in the BlockFilterInstruction that executes notifyAll when the currentBlockNumber is exactly the toBlockNumber, after the nested instructions were executed. This fixes #108, where the BLF won't exit when analyzing a Hyperledger blockchain with a manifest that tries to extract data until the very last block in the ledger.

Example: There are 10 blocks on the ledger. The manifest tries to extract data using a BlockFilter from 5 to 10. In the current state, the BlockFilter will only notify the main thread when reaching block 11, which does not exist, so BLF appears to hang. With this, it will already exit after processing block 10.