### PR TITLE
#113 - kitty id not found in crypto kitties as hyper manifest

### DIFF
--- a/src/main/resources/CryptoKittiesAsHyper.bcql
+++ b/src/main/resources/CryptoKittiesAsHyper.bcql
@@ -12,9 +12,9 @@ SET OUTPUT FOLDER "./test_output"
 
 int[] kitties = newIntArray();
 BLOCKS (32) (91) {
-    LOG ENTRIES ("kitties") (Birth(string owner, uint256 kittyId, uint256 matronID, uint256 sireID, uint256 genes)) {
-        add(kitties, kittyId);
-        EMIT XES EVENT ()(kittyId)()("birth" as xs:string concept:name);
+    LOG ENTRIES ("kitties") (Birth(string owner, uint256 newKittenID, uint256 matronID, uint256 sireID, uint256 genes)) {
+        add(kitties, newKittenID);
+        EMIT XES EVENT ()(newKittenID)()("birth" as xs:string concept:name);
 
         bool containsMatron = contains(kitties, matronID);
         IF (containsMatron) {


### PR DESCRIPTION
Fixes #113.

The name of the variable in the event is wrong in this manifest.