### PR TITLE
#136 - fix block.hash and transaction.hash in Hyperledger extraction are not correct

### DIFF
--- a/src/main/java/blf/blockchains/hyperledger/helpers/HyperledgerListenerHelper.java
+++ b/src/main/java/blf/blockchains/hyperledger/helpers/HyperledgerListenerHelper.java
@@ -1,6 +1,5 @@
 package blf.blockchains.hyperledger.helpers;
 
-import blf.blockchains.hyperledger.HyperledgerListener;
 import blf.blockchains.hyperledger.state.HyperledgerProgramState;
 import blf.core.exceptions.ExceptionHandler;
 import blf.core.exceptions.ProgramException;
@@ -13,6 +12,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -176,5 +176,17 @@ public interface HyperledgerListenerHelper {
         }
 
         return blockNumber;
+    }
+
+    // inspired from: https://stackoverflow.com/questions/9655181/how-to-convert-a-byte-array-to-a-hex-string-in-java
+    static String bytesToHexString(byte[] bytes) {
+        final byte[] hexArray = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
+        byte[] hexChars = new byte[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerBlockFilterInstruction.java
+++ b/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerBlockFilterInstruction.java
@@ -65,7 +65,7 @@ public class HyperledgerBlockFilterInstruction extends FilterInstruction {
                 }
             } else {
                 valueStore.setValue(BLOCK_NUMBER, BigInteger.valueOf(blockEvent.getBlockNumber()));
-                valueStore.setValue(BLOCK_HASH, BigInteger.valueOf(blockEvent.hashCode()));
+                valueStore.setValue(BLOCK_HASH, HyperledgerListenerHelper.bytesToHexString(blockEvent.getDataHash()));
                 valueStore.setValue(BLOCK_TRANSACTION_COUNT, BigInteger.valueOf(blockEvent.getTransactionCount()));
 
                 hyperledgerProgramState.setCurrentBlockNumber(currentBlockNumber);

--- a/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerTransactionFilterInstruction.java
+++ b/src/main/java/blf/blockchains/hyperledger/instructions/HyperledgerTransactionFilterInstruction.java
@@ -26,7 +26,7 @@ import static blf.blockchains.hyperledger.variables.HyperledgerTransactionVariab
 public class HyperledgerTransactionFilterInstruction extends FilterInstruction {
 
     private final BcqlParser.TransactionFilterContext transactionCtx;
-    @SuppressWarnings({"FieldCanBeLocal", "unused"})
+    @SuppressWarnings({ "FieldCanBeLocal", "unused" })
     private final Logger logger;
 
     /**
@@ -91,7 +91,6 @@ public class HyperledgerTransactionFilterInstruction extends FilterInstruction {
                     if (recipientsAddressList.isEmpty() || recipientsAddressList.contains(transactionRecipient)) {
                         ValueStore valueStore = state.getValueStore();
 
-                        valueStore.setValue(TRANSACTION_HASH, BigInteger.valueOf(transactionEvent.hashCode()));
                         valueStore.setValue(TRANSACTION_ID, transactionEvent.getTransactionID());
                         valueStore.setValue(TRANSACTION_CREATOR_ID, transactionEventCreator.getId());
                         valueStore.setValue(TRANSACTION_CREATOR_MSPID, transactionEventCreator.getMspid());

--- a/src/main/java/blf/blockchains/hyperledger/variables/HyperledgerBlockVariables.java
+++ b/src/main/java/blf/blockchains/hyperledger/variables/HyperledgerBlockVariables.java
@@ -15,7 +15,6 @@ public class HyperledgerBlockVariables {
     public static final String BLOCK_HASH = "block.hash";
     public static final String BLOCK_TRANSACTION_COUNT = "block.transactionCount";
 
-    @SuppressWarnings("unused")
     private static final String TYPE_STRING = "string";
     @SuppressWarnings("unused")
     private static final String TYPE_BYTES = "bytes";
@@ -27,7 +26,7 @@ public class HyperledgerBlockVariables {
         BLOCK_VARIABLES = new HashSet<>();
 
         addBlockVariable(BLOCK_NUMBER, TYPE_INT);
-        addBlockVariable(BLOCK_HASH, TYPE_INT);
+        addBlockVariable(BLOCK_HASH, TYPE_STRING);
         addBlockVariable(BLOCK_TRANSACTION_COUNT, TYPE_INT);
     }
 

--- a/src/main/java/blf/blockchains/hyperledger/variables/HyperledgerTransactionVariables.java
+++ b/src/main/java/blf/blockchains/hyperledger/variables/HyperledgerTransactionVariables.java
@@ -12,7 +12,6 @@ public class HyperledgerTransactionVariables {
     static final Set<Variable> TRANSACTION_VARIABLES;
 
     public static final String TRANSACTION_ID = "transaction.id";
-    public static final String TRANSACTION_HASH = "transaction.hash";
     public static final String TRANSACTION_CREATOR_MSPID = "transaction.creatorMspid";
     public static final String TRANSACTION_CREATOR_ID = "transaction.creatorId";
     public static final String TRANSACTION_PEER_NAME = "transaction.peerName";
@@ -38,7 +37,6 @@ public class HyperledgerTransactionVariables {
         TRANSACTION_VARIABLES = new HashSet<>();
 
         addTransactionVariable(TRANSACTION_ID, TYPE_INT);
-        addTransactionVariable(TRANSACTION_HASH, TYPE_STRING);
         addTransactionVariable(TRANSACTION_CREATOR_MSPID, TYPE_INT);
         addTransactionVariable(TRANSACTION_CREATOR_ID, TYPE_INT);
         addTransactionVariable(TRANSACTION_PEER_NAME, TYPE_STRING);

--- a/src/main/resources/HyperBasic.bcql
+++ b/src/main/resources/HyperBasic.bcql
@@ -46,7 +46,6 @@ BLOCKS (blockNumberFrom) (blockNumberTo) {
    TRANSACTIONS (sender) (recipient) {
       EMIT LOG LINE ("====================================================================================");
       EMIT LOG LINE ("transaction.id: ", transaction.id);
-      EMIT LOG LINE ("transaction.hash: ", transaction.hash);
       EMIT LOG LINE ("transaction.creatorMspid: ", transaction.creatorMspid);
       EMIT LOG LINE ("transaction.creatorId: ", transaction.creatorId);
       EMIT LOG LINE ("transaction.peerName: ", transaction.peerName);


### PR DESCRIPTION
Fixes #136.

I found this issue when implementing the e2e tests for Hyperledger. I noticed that the block.hash and transaction.hash were different for every extraction.

This is a blocker for the e2e tests #128!